### PR TITLE
Search client update

### DIFF
--- a/search_client/factories/research_product.py
+++ b/search_client/factories/research_product.py
@@ -30,6 +30,12 @@ NL_MATERIAL = {
         "doi": None,
         "technical_type": "document",
         "research_themes": ["exact_informatica"],
+        "provider": {
+            "ror": None,
+            "external_id": None,
+            "name": "Wikiwijs Maken",
+            "slug": None
+        }
     },
     "biology": {
         "title": "Onderzoek over biologisch denken",
@@ -61,7 +67,13 @@ NL_MATERIAL = {
         "ideas": [],
         "doi": None,
         "technical_type": "document",
-        "research_themes": ["aarde_milieu"]
+        "research_themes": ["aarde_milieu"],
+        "provider": {
+            "ror": None,
+            "external_id": None,
+            "name": "Wikiwijs Maken",
+            "slug": None
+        }
     }
 }
 

--- a/search_client/opensearch/client.py
+++ b/search_client/opensearch/client.py
@@ -4,7 +4,7 @@ from rest_framework.serializers import Serializer
 from opensearchpy import OpenSearch, RequestsHttpConnection
 
 from search_client.constants import DocumentTypes, SEARCH_FIELDS, EDUREP_LEGACY_ID_PREFIXES
-from search_client.serializers import LearningMaterialResultSerializer, ResearchProductResultSerializer
+from search_client.serializers import SimpleLearningMaterialResultSerializer, ResearchProductResultSerializer
 
 
 class SearchClient:
@@ -83,7 +83,7 @@ class SearchClient:
     def get_result_serializer(self) -> Serializer | None:
         match self.document_type:
             case DocumentTypes.LEARNING_MATERIAL:
-                return LearningMaterialResultSerializer()
+                return SimpleLearningMaterialResultSerializer()
             case DocumentTypes.RESEARCH_PRODUCT:
                 return ResearchProductResultSerializer()
             case _:

--- a/search_client/opensearch/client.py
+++ b/search_client/opensearch/client.py
@@ -108,19 +108,6 @@ class SearchClient:
             field_mapping[field]: value
             for field, value in data.items() if field in field_mapping
         }
-        # Reformatting some fields if a relations field is desired
-        if "relations" in field_mapping:
-            publishers = [{"name": publisher} for publisher in data.get("publishers", [])]
-            keywords = data.get("keywords", []) or []
-            record["relations"] = {
-                "authors": data.get("authors", []),
-                "parties": data.get("parties", []) or publishers,
-                "projects": data.get("projects", []),
-                "keywords": [{"label": keyword} for keyword in keywords],
-                "research_themes": [{"label": theme} for theme in data.get("research_themes", [])],
-                "parents": data.get("is_part_of", []),
-                "children": data.get("has_parts", [])
-            }
         # Calling methods on serializers to set data for method fields
         for field_name, field in serializer.fields.items():
             if field.source != "*":

--- a/search_client/serializers.py
+++ b/search_client/serializers.py
@@ -76,6 +76,8 @@ class ResearchProductResultSerializer(BaseSearchResultSerializer):
     parties = serializers.ListField(child=serializers.CharField(), source="publishers")
     research_themes = serializers.ListField(child=serializers.CharField())
     projects = serializers.ListField(child=serializers.CharField(), default=[])
+    owners = serializers.SerializerMethodField(method_name="list_first_author")
+    contacts = serializers.SerializerMethodField(method_name="list_first_author")
 
     def get_provider(self, obj):
         provider = obj["provider"]
@@ -87,3 +89,9 @@ class ResearchProductResultSerializer(BaseSearchResultSerializer):
             return provider["ror"]
         elif provider["external_id"]:
             return provider["external_id"]
+
+    def list_first_author(self, obj):
+        authors = obj["authors"]
+        if not authors:
+            return []
+        return [authors[0]]

--- a/search_client/serializers.py
+++ b/search_client/serializers.py
@@ -44,7 +44,7 @@ class BaseSearchResultSerializer(serializers.Serializer):
 
 class SimpleLearningMaterialResultSerializer(BaseSearchResultSerializer):
 
-    provider = serializers.DictField(default=None, allow_blank=True, allow_null=True)
+    provider = serializers.DictField(default=None, allow_null=True)
     lom_educational_levels = serializers.ListField(child=serializers.CharField())
     studies = serializers.ListField(child=serializers.CharField())
     disciplines = serializers.ListField(child=serializers.CharField(), default=[],

--- a/search_client/serializers.py
+++ b/search_client/serializers.py
@@ -44,7 +44,7 @@ class BaseSearchResultSerializer(serializers.Serializer):
 
 class SimpleLearningMaterialResultSerializer(BaseSearchResultSerializer):
 
-    provider = serializers.DictField()
+    provider = serializers.DictField(default=None, allow_blank=True, allow_null=True)
     lom_educational_levels = serializers.ListField(child=serializers.CharField())
     studies = serializers.ListField(child=serializers.CharField())
     disciplines = serializers.ListField(child=serializers.CharField(), default=[],
@@ -73,7 +73,7 @@ class ResearchProductResultSerializer(BaseSearchResultSerializer):
     type = serializers.CharField(source="technical_type")
     research_object_type = serializers.CharField()
     extension = serializers.DictField()
-    parties = serializers.ListField(child=serializers.CharField())
+    parties = serializers.ListField(child=serializers.CharField(), source="publishers")
     research_themes = serializers.ListField(child=serializers.CharField())
     projects = serializers.ListField(child=serializers.CharField(), default=[])
 

--- a/search_client/version.py
+++ b/search_client/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.3.2"
+VERSION = "0.3.3"

--- a/search_client/version.py
+++ b/search_client/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.3.3"
+VERSION = "0.3.4"


### PR DESCRIPTION
A minor search-client update mostly relevant for Publinova search results (research products instead of learning materials). It does refactor the serializers a bit, because learning materials and research products share more fields now, but I didn't update any of the learning material tests so I don't expect any compatibility problems for Edusources with the refactor.