### PR TITLE
Adds improved phrase search for title, description and text

### DIFF
--- a/search_client/opensearch/client.py
+++ b/search_client/opensearch/client.py
@@ -205,7 +205,8 @@ class SearchClient:
                 "simple_query_string": {
                     "fields": SEARCH_FIELDS[self.document_type],
                     "query": search_text,
-                    "default_operator": "and"
+                    "default_operator": "and",
+                    "quote_field_suffix": ".plain",
                 }
             }
             body["query"]["bool"]["must"] += [query_string]

--- a/search_client/opensearch/configuration.py
+++ b/search_client/opensearch/configuration.py
@@ -74,6 +74,10 @@ def create_open_search_index_configuration(lang: str, document_type: DocumentTyp
                 'title': {
                     'type': 'text',
                     'fields': {
+                        'plain': {
+                            'type': 'text',
+                            'analyzer': language_analyzers.get(lang, "standard"),
+                        },
                         'analyzed': {
                             'type': 'text',
                             'analyzer': language_analyzers.get(lang, "standard"),
@@ -88,6 +92,10 @@ def create_open_search_index_configuration(lang: str, document_type: DocumentTyp
                 'text': {
                     'type': 'text',
                     'fields': {
+                        'plain': {
+                            'type': 'text',
+                            'analyzer': language_analyzers.get(lang, "standard"),
+                        },
                         'analyzed': {
                             'type': 'text',
                             'analyzer': language_analyzers.get(lang, "standard"),
@@ -102,6 +110,10 @@ def create_open_search_index_configuration(lang: str, document_type: DocumentTyp
                 'description': {
                     'type': 'text',
                     'fields': {
+                        'plain': {
+                            'type': 'text',
+                            'analyzer': language_analyzers.get(lang, "standard"),
+                        },
                         'analyzed': {
                             'type': 'text',
                             'analyzer': language_analyzers.get(lang, "standard"),


### PR DESCRIPTION
This makes Open Search look in a non-decompounded field before it looks elsewhere when doing phrase searches like: "I'm looking for this". Problem is that this doesn't solve any problems currently. It doesn't bring "labvaardigheden" matches to the front, because they don't exist. It does cut 1/3 of results for "het lab". So I'm expecting this to do some work for some queries.