### PR TITLE
Adds configurations and models to read and write product metrics

### DIFF
--- a/search_client/opensearch/configuration/products.py
+++ b/search_client/opensearch/configuration/products.py
@@ -81,7 +81,7 @@ def build_product_search_configuration(platform: Platforms) -> SearchConfigurati
         },
         filter_fields=filter_fields,
         range_filter_fields={
-            "published_at", "modified_at",
+            "published_at", "modified_at", "metrics.stars.average",
             "publisher_date"  # deprecated, use published_at
         },
         highlights={

--- a/search_client/opensearch/indices/products.py
+++ b/search_client/opensearch/indices/products.py
@@ -182,6 +182,22 @@ def build_products_index_configuration(product_type: DocumentTypes,
                 "provider": {  # a cross-entity filter field
                     "type": "keyword"
                 },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "views": {
+                            "type": "integer",
+                        },
+                        "stars": {
+                            "type": "object",
+                            "properties": {
+                                "average": {
+                                    "type": "float",
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/search_client/serializers/core.py
+++ b/search_client/serializers/core.py
@@ -20,3 +20,17 @@ class Provider(BaseModel):
 class Highlight(BaseModel):
     description: list[str] | None = Field(default=None)
     text: list[str] | None = Field(default=None)
+
+
+class StarRatings(BaseModel):
+    average: float = Field(default=0.0)
+    star_1: int = Field(default=0)
+    star_2: int = Field(default=0)
+    star_3: int = Field(default=0)
+    star_4: int = Field(default=0)
+    star_5: int = Field(default=0)
+
+
+class Metrics(BaseModel):
+    views: int = Field(default=0)
+    stars: StarRatings

--- a/search_client/serializers/products.py
+++ b/search_client/serializers/products.py
@@ -6,7 +6,7 @@ from pydantic import (BaseModel, Field, field_serializer, computed_field, field_
 from pydantic.networks import HttpUrl
 
 from search_client.constants import LANGUAGES, Entities
-from search_client.serializers.core import EntityStates, Provider, Highlight
+from search_client.serializers.core import EntityStates, Provider, Highlight, Metrics
 from search_client.serializers.files import Video, Previews, File
 from search_client.serializers.persons import Author
 
@@ -40,6 +40,7 @@ class Product(BaseModel):
     doi: str | None = Field(default=None)
     subtitle: str | None = Field(default=None)
     highlight: Highlight | None = Field(default=None)
+    metrics: Metrics | None = Field(default=None)
 
     @field_serializer("provider")
     def serialize_provider(self, provider: Provider, _info) -> str:

--- a/search_client/test/factories/learning_material.py
+++ b/search_client/test/factories/learning_material.py
@@ -53,7 +53,17 @@ NL_MATERIAL = {
             "full_size": "https://surfpol-harvester-content-dev.s3.amazonaws.com/pdf.png",
             "preview_small": "https://surfpol-harvester-content-dev.s3.amazonaws.com/pdf-thumbnail-200x150.png"
         },
-        "provider": "Wikiwijs Maken"
+        "provider": "Wikiwijs Maken",
+        "metrics": {
+            "views": 1,
+            "stars": {
+                "average": 5.0,
+                "star_1": 0,
+                "star_2": 0,
+                "star_4": 0,
+                "star_5": 1
+            }
+        }
     },
     "biology": {
         "srn": "edurep:wikiwijsmaken:wikiwijsmaken:123",
@@ -193,7 +203,18 @@ MATERIALS = {
             "full_size": "https://surfpol-harvester-content-dev.s3.amazonaws.com/pdf.png",
             "preview_small": "https://surfpol-harvester-content-dev.s3.amazonaws.com/pdf-thumbnail-200x150.png"
         },
+
         "provider": "Wikiwijs Maken",
+        "metrics": {
+            "views": 1,
+            "stars": {
+                "average": 5.0,
+                "star_1": 0,
+                "star_2": 0,
+                "star_4": 0,
+                "star_5": 1
+            }
+        },
         "texts": {
             "en": {},
             "unk": {},

--- a/search_client/test/factories/research_product.py
+++ b/search_client/test/factories/research_product.py
@@ -45,6 +45,16 @@ NL_PRODUCT = {
         "technical_type": "document",
         "research_themes": ["exact_informatica"],
         "provider": "Wikiwijs Maken",
+        "metrics": {
+            "views": 1,
+            "stars": {
+                "average": 5.0,
+                "star_1": 0,
+                "star_2": 0,
+                "star_4": 0,
+                "star_5": 1
+            }
+        },
     },
     "biology": {
         "srn": "edurep:wikiwijsmaken:wikiwijsmaken:123",
@@ -190,7 +200,17 @@ PRODUCTS = {
                 ],
                 "transcriptions": []
             }
-        }
+        },
+        "metrics": {
+            "views": 1,
+            "stars": {
+                "average": 5.0,
+                "star_1": 0,
+                "star_2": 0,
+                "star_4": 0,
+                "star_5": 1
+            }
+        },
     },
     "biology": {
         "srn": "edurep:wikiwijsmaken:wikiwijsmaken:123",

--- a/tests/test_backward_compatability.py
+++ b/tests/test_backward_compatability.py
@@ -134,6 +134,17 @@ class TestPydanticToDictConversion(TestCase):
             "consortium": None,
             "subtitle": None,
             "highlight": None,  # only gets added during actual search
+            "metrics": {
+                "views": 1,
+                "stars": {
+                    "average": 5.0,
+                    "star_1": 0,
+                    "star_2": 0,
+                    "star_3": 0,
+                    "star_4": 0,
+                    "star_5": 1
+                }
+            },
         })
 
     def test_research_product_math(self):
@@ -253,6 +264,17 @@ class TestPydanticToDictConversion(TestCase):
                 }
             ],
             "highlight": None,  # only gets added during actual search
+            "metrics": {
+                "views": 1,
+                "stars": {
+                    "average": 5.0,
+                    "star_1": 0,
+                    "star_2": 0,
+                    "star_3": 0,
+                    "star_4": 0,
+                    "star_5": 1
+                }
+            },
         })
 
     def test_learning_material_biology(self):
@@ -328,7 +350,8 @@ class TestPydanticToDictConversion(TestCase):
             "publishers": [
                 "Wikiwijs Maken"
             ],
-            "consortium": None
+            "consortium": None,
+            "metrics": None
         })
 
     maxDiff = None
@@ -423,7 +446,8 @@ class TestPydanticToDictConversion(TestCase):
                     "external_id": None,
                     "is_external": None
                 }
-            ]
+            ],
+            "metrics": None
         })
 
     def test_learning_material_math_all_languages(self):
@@ -530,6 +554,17 @@ class TestPydanticToDictConversion(TestCase):
             "consortium": "SURF",
             "subtitle": None,
             "highlight": None,  # only gets added during actual search
+            "metrics": {
+                "views": 1,
+                "stars": {
+                    "average": 5.0,
+                    "star_1": 0,
+                    "star_2": 0,
+                    "star_3": 0,
+                    "star_4": 0,
+                    "star_5": 1
+                }
+            },
         })
 
     def test_learning_material_biology_all_languages(self):
@@ -605,7 +640,8 @@ class TestPydanticToDictConversion(TestCase):
             "publishers": [
                 "Wikiwijs Maken"
             ],
-            "consortium": None
+            "consortium": None,
+            "metrics": None
         })
 
     def test_research_product_math_all_languages(self):
@@ -724,7 +760,18 @@ class TestPydanticToDictConversion(TestCase):
                     "orcid": None,
                     "is_external": None
                 }
-            ]
+            ],
+            "metrics": {
+                "views": 1,
+                "stars": {
+                    "average": 5.0,
+                    "star_1": 0,
+                    "star_2": 0,
+                    "star_3": 0,
+                    "star_4": 0,
+                    "star_5": 1
+                }
+            },
         })
 
     def test_research_product_biology_all_languages(self):
@@ -817,5 +864,6 @@ class TestPydanticToDictConversion(TestCase):
                     "orcid": None,
                     "is_external": None
                 }
-            ]
+            ],
+            "metrics": None
         })


### PR DESCRIPTION
It's not possible to use metrics like view counts and star ratings with DET's Search API. This PR adds functionality to the client that can handle such data for products. In the future this might get added to projects as well. 

It's expected to only get used by MBO in the harvester, but it will be enabled for all harvester variants (Edusources WO, Publinova, Edusources MBO).

An additional benefit is that it is now possible to sort results on star ratings, but that data needs to be provided to the search engine of course. Currently only the DET Products API provides an interface to deliver that data. The product module retains view data even when source data gets reset.